### PR TITLE
data: fix invalid key ordering in dict_to_dnode

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -208,17 +208,17 @@ class DataTest(unittest.TestCase):
             'number': [1000, 2000, 3000],
             'url': [
                 {
-                    'proto': 'https',
-                    'host': 'github.com',
-                    'path': '/CESNET/libyang-python',
                     'enabled': False,
+                    'path': '/CESNET/libyang-python',
+                    'host': 'github.com',
+                    'proto': 'https',
                 },
                 {
-                    'proto': 'http',
-                    'host': 'foobar.com',
                     'port': 8080,
+                    'proto': 'http',
                     'path': '/index.html',
                     'enabled': True,
+                    'host': 'foobar.com',
                 },
             ],
         },
@@ -296,17 +296,17 @@ class DataTest(unittest.TestCase):
         invalid_dict = {
             'url': [
                 {
-                    'proto': 'https',
                     'host': 'github.com',
-                    'path': '/CESNET/libyang-python',
+                    'proto': 'https',
                     'enabled': False,
+                    'path': '/CESNET/libyang-python',
                 },
                 {
                     'proto': 'http',
-                    'host': 'foobar.com',
-                    'port': 'INVALID.PORT',
                     'path': '/index.html',
                     'enabled': True,
+                    'host': 'foobar.com',
+                    'port': 'INVALID.PORT',
                 },
             ],
         }


### PR DESCRIPTION
Depending on the Python version and/or the way that dictionaries are created and stored, the iteration order of keys is neither stable nor predictable.

For instance, the unit tests do not work on python 3.5 because the [creation order of the dictionary keys iteration is only preserved since python 3.6](https://docs.python.org/3.6/whatsnew/3.6.html#new-dict-implementation). Before that, it is random. They work on other versions of python because the dictionaries are actually defined with the keys first and in the correct order.

However, libyang requires that the first children of a list node are its keys and they must be in the order defined in the YANG schema. When a data tree has a key in the wrong position, we get an error during lyd_validate:

```
Missing required element "keyname" in "somelist".: Invalid position of the key element.
```

When converting a list element, make sure to create the list keys first.

Mangle the dictionaries in unit tests to ensure that the keys order is respected.

Fixes: 0a1e53c3c481 ("data: optimize dict_to_dnode")