### PR TITLE
Fix dict conversion for rpcs

### DIFF
--- a/libyang/data.py
+++ b/libyang/data.py
@@ -606,7 +606,7 @@ def dict_to_dnode(dic, module, parent=None, rpc=False, rpcreply=False,
                   in_rpc_output=rpcreply and isinstance(parent, DRpc))
         if created:
             result = DNode.new(module.context, created[0])
-            result.validate(rpc=rpc, rpcreply=rpc,
+            result.validate(rpc=rpc, rpcreply=rpcreply,
                             data=data, config=config, no_yanglib=no_yanglib)
     except:
         for c in reversed(created):

--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -118,7 +118,8 @@ class Module:
             raise self.context.error('cannot print module')
 
     def parse_data_dict(self, dic, rpc=False, rpcreply=False, strict=False,
-                        data=False, config=False, no_yanglib=False):
+                        data=False, config=False, no_yanglib=False,
+                        validate=True):
         """
         Convert a python dictionary to a DNode object following the schema of
         this module. The returned value is always a top-level data node (i.e.:
@@ -142,11 +143,14 @@ class Module:
         :arg bool no_yanglib:
             Ignore (possibly) missing ietf-yang-library data. Applicable only
             with data=True.
+        :arg bool validate:
+            If False, do not validate the created data tree.
         """
         from .data import dict_to_dnode  # circular import
         return dict_to_dnode(dic, self, parent=None,
                              rpc=rpc, rpcreply=rpcreply, strict=strict,
-                             data=data, config=config, no_yanglib=no_yanglib)
+                             data=data, config=config, no_yanglib=no_yanglib,
+                             validate=validate)
 
 
 #------------------------------------------------------------------------------

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -324,8 +324,13 @@ class DataTest(unittest.TestCase):
     def test_data_from_dict_container(self):
         dnode = self.ctx.create_data_path('/yolo-system:conf')
         self.assertIsInstance(dnode, DContainer)
-        dnode.merge_data_dict(self.DICT_CONFIG['conf'], strict=True, config=True)
+        subtree = dnode.merge_data_dict(
+            self.DICT_CONFIG['conf'], strict=True, config=True, validate=False)
+        # make sure subtree validation is forbidden
+        with self.assertRaises(LibyangError):
+            subtree.validate(config=True)
         try:
+            dnode.validate(config=True)
             j = dnode.print_mem('json', pretty=True)
         finally:
             dnode.free()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -345,7 +345,7 @@ class DataTest(unittest.TestCase):
         dnode = self.ctx.create_data_path('/yolo-system:format-disk')
         self.assertIsInstance(dnode, DRpc)
         dnode.merge_data_dict(
-            {'duration': 42}, rpcreply=True, strict=True, no_yanglib=True)
+            {'duration': 42}, rpcreply=True, strict=True)
         try:
             j = dnode.print_mem('json')
         finally:

--- a/tox-install.sh
+++ b/tox-install.sh
@@ -32,7 +32,7 @@ download()
 # build and install libyang into the virtualenv
 src="${LIBYANG_SRC:-$venv/.src}"
 if ! [ -d "$src" ]; then
-	libyang_branch="${LIBYANG_BRANCH:-${TRAVIS_BRANCH:-devel}}"
+	libyang_branch="${LIBYANG_BRANCH:-devel}"
 	download "https://github.com/CESNET/libyang" "$libyang_branch" "$src"
 fi
 


### PR DESCRIPTION
There is a typo. However, now that I fixed it, the validation fails complaining about a missing required element that is not even present in the test YANG schema.

```
Missing required element "notification" in "duration".
```

I must have misunderstood the use of the `LYD_OPT_RPCREPLY` flag for `lyd_validate()`. @michalvasko can you shine some light on this? Can you tell me what I am doing wrong?