### PR TITLE
Fix find_all function and add test for it

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -316,6 +316,7 @@ struct lys_node_list {
 
 union ly_set_set {
 	struct lys_node **s;
+	struct lyd_node **d;
 	...;
 };
 

--- a/libyang/data.py
+++ b/libyang/data.py
@@ -241,7 +241,7 @@ class DNode:
             raise self.context.error("cannot find path")
         try:
             for i in range(node_set.number):
-                yield DNode.new(self.context, node_set.d[i])
+                yield DNode.new(self.context, node_set.set.d[i])
         finally:
             lib.ly_set_free(node_set)
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,7 +7,7 @@ import unittest
 from unittest.mock import patch
 
 from _libyang import lib
-from libyang import Context, DContainer, DDiff, DRpc, LibyangError
+from libyang import Context, DContainer, DDiff, DNode, DRpc, LibyangError
 
 
 YANG_DIR = os.path.join(os.path.dirname(__file__), "yang")
@@ -565,3 +565,34 @@ class DataTest(unittest.TestCase):
 
         dnode1.free()
         dnode2.free()
+
+    def test_find_one(self):
+        dnode = self.ctx.parse_data_mem(self.JSON_CONFIG, "json", config=True)
+        self.assertIsInstance(dnode, DContainer)
+        try:
+            hostname = dnode.find_one("hostname")
+            self.assertIsInstance(hostname, DNode)
+            self.assertEqual(hostname.name(), "hostname")
+        finally:
+            dnode.free()
+
+    def test_find_all(self):
+        dnode = self.ctx.parse_data_mem(self.JSON_CONFIG, "json", config=True)
+        self.assertIsInstance(dnode, DContainer)
+        try:
+            urls = dnode.find_all("url")
+            urls = list(urls)
+            self.assertEqual(len(urls), 2)
+            expected_url = {
+                "url": [
+                    {
+                        "proto": "https",
+                        "host": "github.com",
+                        "path": "/CESNET/libyang-python",
+                        "enabled": False,
+                    }
+                ]
+            }
+            self.assertEqual(urls[0].print_dict(absolute=False), expected_url)
+        finally:
+            dnode.free()


### PR DESCRIPTION
The `find_one` and `find_all` method does not work due to the following error: 

```
AttributeError: cdata 'struct ly_set *' has no field 'd'
```

I fixed the issue and added a test for the `find_one` method. 