### PR TITLE
README: fix data tree example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ Data Tree
    ...             {'name': 'lo', 'address': '127.0.0.1'},
    ...         ],
    ...     },
-   ... })
+   ... }, config=True)
    >>> print(node.print_mem('xml', pretty=True))
    <data xmlns="urn:example">
      <interface>


### PR DESCRIPTION
Fix the following error when running the data tree example provided in README:

```
 LibyangError: validation failed: Missing required element "content-id" in "yang-library".
```

When parsing a config tree, we do not have the complete datastore available (no ietf-yang-library.yang module data).

Link: https://github.com/CESNET/libyang-python/blob/v1.6.1/libyang/schema.py#L154-L155
Link: https://netopeer.liberouter.org/doc/libyang/master/html/group__parseroptions.html
Fixes: #21