### PR TITLE
data: add an option to allow a keyless list to print_dict()

### DIFF
--- a/libyang/data.py
+++ b/libyang/data.py
@@ -420,6 +420,7 @@ class DNode:
         include_implicit_defaults: bool = False,
         trim_default_values: bool = False,
         keep_empty_containers: bool = False,
+        allow_keyless_list: bool = False,
     ) -> Dict[str, Any]:
         """
         Convert a DNode object to a python dictionary.
@@ -438,6 +439,8 @@ class DNode:
             Exclude nodes with the value equal to their default value.
         :arg bool keep_empty_containers:
             Preserve empty non-presence containers.
+        :arg bool allow_keyless_list:
+            If True, allow key-less list.
         """
         flags = printer_flags(
             include_implicit_defaults=include_implicit_defaults,
@@ -474,6 +477,8 @@ class DNode:
                 for i in range(list_snode.keys_size):
                     key = ffi.cast("struct lys_node *", list_snode.keys[i])
                     keys.append(c2str(key.name))
+                if allow_keyless_list and len(keys) == 0:
+                    return []
                 if len(keys) == 1:
                     list_keys_cache[snode] = keys[0]
                 else:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -512,6 +512,22 @@ class DataTest(unittest.TestCase):
             dnotif.free()
         self.assertEqual(json.loads(j), json.loads(self.JSON_NOTIF))
 
+    DICT_NOTIF_KEYLESS_LIST = {
+        "config-change": {"edit": [{"target": "a"}, {"target": "b"}]},
+    }
+
+    def test_data_to_dict_keyless_list(self):
+        module = self.ctx.get_module("yolo-system")
+        dnotif = module.parse_data_dict(
+            self.DICT_NOTIF_KEYLESS_LIST, strict=True, notification=True
+        )
+        self.assertIsInstance(dnotif, DNotif)
+        try:
+            dic = dnotif.print_dict(allow_keyless_list=True)
+        finally:
+            dnotif.free()
+        self.assertEqual(dic, self.DICT_NOTIF_KEYLESS_LIST)
+
     XML_DIFF_STATE1 = """<state xmlns="urn:yang:yolo:system">
   <hostname>foo</hostname>
   <speed>1234</speed>

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -71,6 +71,12 @@ class DiffTest(unittest.TestCase):
             (SNodeAdded, "/yolo-system:alarm-triggered"),
             (SNodeAdded, "/yolo-system:alarm-triggered/yolo-system:severity"),
             (SNodeAdded, "/yolo-system:alarm-triggered/yolo-system:description"),
+            (
+                SNodeAdded,
+                "/yolo-system:config-change/yolo-system:edit/yolo-system:target",
+            ),
+            (SNodeAdded, "/yolo-system:config-change/yolo-system:edit"),
+            (SNodeAdded, "/yolo-system:config-change"),
             (EnumRemoved, "/yolo-system:conf/yolo-system:url/yolo-system:proto"),
             (EnumRemoved, "/yolo-system:state/yolo-system:url/yolo-system:proto"),
             (EnumStatusAdded, "/yolo-system:conf/yolo-system:url/yolo-system:proto"),

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -52,7 +52,7 @@ class ModuleTest(unittest.TestCase):
 
     def test_mod_iter(self):
         children = list(iter(self.module))
-        self.assertEqual(len(children), 5)
+        self.assertEqual(len(children), 6)
 
     def test_mod_children_rpcs(self):
         rpcs = list(self.module.children(types=(SNode.RPC,)))

--- a/tests/yang/yolo/yolo-system.yang
+++ b/tests/yang/yolo/yolo-system.yang
@@ -168,4 +168,12 @@ module yolo-system {
       type uint32;
     }
   }
+
+  notification config-change {
+    list edit {
+      leaf target {
+        type string;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Keyless list is allowed for operational data. (see RFC7950 7.8.2.)
It is used in ietf-netconf-notifications:netconf-config-change, for example.

Signed-off-by: Wataru Ishida <wataru.ishid@gmail.com>