### PR TITLE
refactor v2 api to be more compatible with v1

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -312,6 +312,7 @@ LY_ERR lyd_print_all(struct ly_out *, const struct lyd_node *, LYD_FORMAT, uint3
 #define LYD_VALIDATE_OPTS_MASK ...
 
 LY_ERR lyd_parse_data_mem(const struct ly_ctx *, const char *, LYD_FORMAT, uint32_t, uint32_t, struct lyd_node **);
+LY_ERR lyd_parse_data_fd(const struct ly_ctx *,	int , LYD_FORMAT, uint32_t, uint32_t, struct lyd_node **);
 
 struct ly_in;
 struct ly_out;

--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -181,8 +181,7 @@ class Module:
     def parse_data_dict(
         self,
         dic: Dict[str, Any],
-        no_state: bool = False,
-        validate_present: bool = False,
+        config: bool = False,
         validate: bool = True,
         strict: bool = False,
         rpc: bool = False,
@@ -196,10 +195,8 @@ class Module:
 
         :arg dic:
             The python dictionary to convert.
-        :arg no_state:
+        :arg config:
             Consider state data not allowed and raise an error during validation if they are found.
-        :arg validate_present:
-            Validate result of the operation against schema.
         :arg validate:
             Run validation on result of the operation.
         :arg strict:
@@ -216,8 +213,7 @@ class Module:
         return dict_to_dnode(
             dic,
             self,
-            no_state=no_state,
-            validate_present=validate_present,
+            config=config,
             validate=validate,
             strict=strict,
             rpc=rpc,


### PR DESCRIPTION
Parse data should use the builtin functions of libyang instead of reimplementing it from raw parsing.