### PR TITLE
context: fix duplicate path error

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -29,6 +29,13 @@ class ContextTest(unittest.TestCase):
         with Context(YANG_DIR) as ctx:
             self.assertIsNot(ctx, None)
 
+    def test_ctx_duplicate_searchpath(self):
+        duplicate_search_path = ":".join([YANG_DIR, YANG_DIR])
+        try:
+            Context(duplicate_search_path)
+        except LibyangError:
+            self.fail("Context.__init__ should not raise LibyangError")
+
     def test_ctx_invalid_dir(self):
         with Context("/does/not/exist") as ctx:
             self.assertIsNot(ctx, None)


### PR DESCRIPTION
search_dirs can contain duplicate path if YANGPATH envvar is used.
With libyang1, we can add several time the same searchdir without
problem but with libyang2, ly_ctx_set_searchdir returns an error if we
add a path already existant.

To fix it, we now pass the search dir directly when creating the
context.