### PR TITLE
schema: add state method for conditional if-features

### DIFF
--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -793,6 +793,9 @@ class IfFeature(IfFeatureExprTree):
     def feature(self) -> Feature:
         return Feature(self.context, self.cdata)
 
+    def state(self) -> bool:
+        return self.feature().state()
+
     def dump(self, indent: int = 0) -> str:
         feat = self.feature()
         return "%s%s [%s]\n" % (" " * indent, feat.name(), feat.description())
@@ -809,6 +812,9 @@ class IfNotFeature(IfFeatureExprTree):
     def __init__(self, context: "libyang.Context", child: IfFeatureExprTree):
         self.context = context
         self.child = child
+
+    def state(self) -> bool:
+        return not self.child.state()
 
     def dump(self, indent: int = 0) -> str:
         return " " * indent + "NOT\n" + self.child.dump(indent + 1)
@@ -828,6 +834,9 @@ class IfAndFeatures(IfFeatureExprTree):
         self.context = context
         self.a = a
         self.b = b
+
+    def state(self) -> bool:
+        return self.a.state() and self.b.state()
 
     def dump(self, indent: int = 0) -> str:
         s = " " * indent + "AND\n"
@@ -850,6 +859,9 @@ class IfOrFeatures(IfFeatureExprTree):
         self.context = context
         self.a = a
         self.b = b
+
+    def state(self) -> bool:
+        return self.a.state() or self.b.state()
 
     def dump(self, indent: int = 0) -> str:
         s = " " * indent + "OR\n"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -38,6 +38,8 @@ class DiffTest(unittest.TestCase):
             (NodeTypeAdded, "/yolo-system:state/number"),
             (NodeTypeRemoved, "/yolo-system:conf/number"),
             (NodeTypeRemoved, "/yolo-system:state/number"),
+            (SNodeAdded, "/yolo-system:conf/full"),
+            (SNodeAdded, "/yolo-system:state/full"),
             (SNodeAdded, "/yolo-system:conf/hostname-ref"),
             (SNodeAdded, "/yolo-system:conf/url/enabled"),
             (SNodeAdded, "/yolo-system:conf/url/fetch"),

--- a/tests/yang/yolo/yolo-system.yang
+++ b/tests/yang/yolo/yolo-system.yang
@@ -106,6 +106,20 @@ module yolo-system {
       type uint32;
     }
 
+    leaf offline {
+      description
+        "When networking is disabled.";
+      if-feature "not networking";
+      type uint32;
+    }
+
+    leaf full {
+      description
+        "Fast and online.";
+      if-feature "turbo-boost and networking";
+      type uint32;
+    }
+
     leaf isolation-level {
       description
         "The level of isolation.";


### PR DESCRIPTION
Accessing feature states is useful to enable/disable leafs.
However, when a if-feature contain a condition (not/or/and keywords),
there is currently no way to get the state resulting of the expression.

Add a state method to all IfFeatureExpr objects so a state of the
entire if-feature expression can be evaluated.

Test all basic cases (one operator).