### PR TITLE
data: update free method

### DIFF
--- a/libyang/data.py
+++ b/libyang/data.py
@@ -216,7 +216,7 @@ class DNode:
         """
         self.context = context
         self.cdata = cdata  # C type: "struct lyd_node *"
-        self.free_func = None  # type: Callable[struct lyd_node *]
+        self.free_func = None  # type: Callable[DNode]
 
     def meta(self):
         ret = {}
@@ -790,14 +790,18 @@ class DNode:
             rpcreply=rpcreply,
         )
 
+    def free_internal(self, with_siblings: bool = True) -> None:
+        if with_siblings:
+            lib.lyd_free_all(self.cdata)
+        else:
+            lib.lyd_free_tree(self.cdata)
+
     def free(self, with_siblings: bool = True) -> None:
         try:
             if self.free_func:
-                self.free_func(self.cdata)  # pylint: disable=not-callable
-            elif with_siblings:
-                lib.lyd_free_all(self.cdata)
+                self.free_func(self)  # pylint: disable=not-callable
             else:
-                lib.lyd_free_tree(self.cdata)
+                self.free_internal(with_siblings)
         finally:
             self.cdata = None
 


### PR DESCRIPTION
Currently, if we use the free_func feature, we can't call the free
method (similary to a parent method). If we do, we enter in an infinite
loop.

This patch allows to call free_internal from the free_func in order to
avoid infinite loop.