### PR TITLE
data: force key_values to str

### DIFF
--- a/libyang/data.py
+++ b/libyang/data.py
@@ -1094,7 +1094,7 @@ def dict_to_dnode(
             str2c(name),
             in_rpc_output,
             n,
-            *[str2c(i) for i in key_values],
+            *[str2c(str(i)) for i in key_values],
         )
         if ret != lib.LY_SUCCESS:
             if _parent:


### PR DESCRIPTION
In a SList, if you have a key not in str type (uint16 for example), the
str2c function will not manage to convert it to cdata str because it
waits only for str type.

So we force str type in order to fix this problem.