### PR TITLE
xpath: properly process key names with \ in xpath_split

### DIFF
--- a/libyang/xpath.py
+++ b/libyang/xpath.py
@@ -60,13 +60,11 @@ def xpath_split(xpath: str) -> Iterator[Tuple[str, str, List[Tuple[str, str]]]]:
             quote = xpath[j + 1]  # record opening quote character
             j = i = j + 2  # skip '=' and opening quote
             while True:
-                if xpath[j] == "\\":
-                    j += 1  # skip escaped character
-                elif xpath[j] == quote:
-                    break  # end of key value
+                if xpath[j] == quote and xpath[j - 1] != "\\":
+                    break
                 j += 1
             # replace escaped chars by their non-escape version
-            key_value = xpath[i:j].replace("\\", "")
+            key_value = xpath[i:j].replace(f"\\{quote}", f"{quote}")
             keys.append((key_name, key_value))
             i = j + 2  # skip closing quote and ']'
 

--- a/tests/test_xpath.py
+++ b/tests/test_xpath.py
@@ -236,6 +236,7 @@ XPATH_SPLIT_EXPECTED_RESULTS = {
     "/nam1/p:nam2": [(None, "nam1", []), ("p", "nam2", [])],
     '/p:nam/lst[k1="foo"]': [("p", "nam", []), (None, "lst", [("k1", "foo")])],
     '/p:nam/lst[.="foo"]': [("p", "nam", []), (None, "lst", [(".", "foo")])],
+    '/p:nam/lst[.="foo\\bar"]': [("p", "nam", []), (None, "lst", [(".", "foo\\bar")])],
     "/nam/p:lst[k1='foo'][k2='bar']/x": [
         (None, "nam", []),
         ("p", "lst", [("k1", "foo"), ("k2", "bar")]),


### PR DESCRIPTION
There is no reason to remove the '\' in a key name if they are not
escaping a quote. Leave them untouched.

Signed-off-by: Samuel Gauthier <samuel.gauthier@6wind.com>