### PR TITLE
context: add explicit_compile option

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -205,6 +205,7 @@ struct lys_module* ly_ctx_load_module(struct ly_ctx *, const char *, const char 
 struct lys_module* ly_ctx_get_module(const struct ly_ctx *, const char *, const char *);
 struct lys_module* ly_ctx_get_module_iter(const struct ly_ctx *, uint32_t *);
 struct lys_module* ly_ctx_get_module_latest(const struct ly_ctx *, const char *);
+LY_ERR ly_ctx_compile(struct ly_ctx *);
 
 LY_ERR lys_find_xpath(const struct ly_ctx *, const struct lysc_node *, const char *, uint32_t, struct ly_set **);
 void ly_set_free(struct ly_set *, void(*)(void *obj));

--- a/libyang/context.py
+++ b/libyang/context.py
@@ -28,6 +28,7 @@ class Context:
         self,
         search_path: Optional[str] = None,
         disable_searchdir_cwd: bool = True,
+        explicit_compile: Optional[bool] = False,
         yanglib_path: Optional[str] = None,
         yanglib_fmt: str = "json",
         cdata=None,  # C type: "struct ly_ctx *"
@@ -39,6 +40,8 @@ class Context:
         options = 0
         if disable_searchdir_cwd:
             options |= lib.LY_CTX_DISABLE_SEARCHDIR_CWD
+        if explicit_compile:
+            options |= lib.LY_CTX_EXPLICIT_COMPILE
         # force priv parsed
         options |= lib.LY_CTX_SET_PRIV_PARSED
 
@@ -78,6 +81,11 @@ class Context:
         )
         if not self.cdata:
             raise self.error("cannot create context")
+
+    def compile_schema(self):
+        ret = lib.ly_ctx_compile(self.cdata)
+        if ret != lib.LY_SUCCESS:
+            raise self.error("could not compile schema")
 
     def get_yanglib_data(self, content_id_format=""):
         dnode = ffi.new("struct lyd_node **")


### PR DESCRIPTION
Today, loading modules in a context is very slow, because each time a
module is added, the whole schema is recompiled. Libyang has a flag to
defer the compilation to a later ly_ctx_compile call. Let's expose
this feature.

Signed-off-by: Samuel Gauthier <samuel.gauthier@6wind.com>