### PR TITLE
schema: check cdata_parsed before using it

### DIFF
--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -515,6 +515,8 @@ class Type:
     NUM_TYPES = frozenset((INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64))
 
     def range(self) -> Optional[str]:
+        if not self.cdata_parsed:
+            return None
         if (
             self.cdata.basetype in self.NUM_TYPES or self.cdata.basetype == self.DEC64
         ) and self.cdata_parsed.range != ffi.NULL:


### PR DESCRIPTION
Sometimes, cdata_parsed is None. Check it before using it, as we do in
the other functions using cdata_parsed.

It fixes this error:
AttributeError: 'NoneType' object has no attribute 'range'

Signed-off-by: Samuel Gauthier <samuel.gauthier@6wind.com>