### PR TITLE
Add function prototype for lyd_insert_sibling

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -963,6 +963,7 @@ LY_ERR lyd_any_value_str(const struct lyd_node *, char **);
 LY_ERR lyd_merge_tree(struct lyd_node **, const struct lyd_node *, uint16_t);
 LY_ERR lyd_merge_siblings(struct lyd_node **, const struct lyd_node *, uint16_t);
 LY_ERR lyd_insert_child(struct lyd_node *, struct lyd_node *);
+LY_ERR lyd_insert_sibling(struct lyd_node *, struct lyd_node *, struct lyd_node **);
 LY_ERR lyd_diff_apply_all(struct lyd_node **, const struct lyd_node *);
 
 #define LYD_DUP_NO_META  ...


### PR DESCRIPTION
Add `lyd_insert_sibling` function prototype to `cdefs.h` to expose it to Python FFI. Related to issue https://github.com/CESNET/libyang-python/issues/49