### PR TITLE
schema: fix type extensions

### DIFF
--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -576,11 +576,8 @@ class Type:
         return Module(self.context, self.cdata.der.module)
 
     def extensions(self) -> Iterator[ExtensionCompiled]:
-        for i in range(self.cdata.ext_size):
-            yield ExtensionCompiled(self.context, self.cdata.ext[i])
-        if self.cdata.parent:
-            for i in range(self.cdata.parent.ext_size):
-                yield ExtensionCompiled(self.context, self.cdata.parent.ext[i])
+        for extension in ly_array_iter(self.cdata.exts):
+            yield ExtensionCompiled(self.context, extension)
 
     def get_extension(
         self, name: str, prefix: Optional[str] = None, arg_value: Optional[str] = None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -401,6 +401,16 @@ class LeafTypeTest(unittest.TestCase):
         bases = set(t.basenames())
         self.assertEqual(bases, set(["int16", "int32", "uint16", "uint32"]))
 
+    def test_leaf_type_extensions(self):
+        leaf = next(
+            self.ctx.find_path("/yolo-system:conf/yolo-system:url/yolo-system:proto")
+        )
+        t = leaf.type()
+        ext = t.get_extension(
+            "type-desc", prefix="omg-extensions", arg_value="<protocol>"
+        )
+        self.assertIsInstance(ext, Extension)
+
     def test_leaf_type_enum(self):
         leaf = next(
             self.ctx.find_path("/yolo-system:conf/yolo-system:url/yolo-system:proto")

--- a/tests/yang/omg/omg-extensions.yang
+++ b/tests/yang/omg/omg-extensions.yang
@@ -12,4 +12,10 @@ module omg-extensions {
       "Extend a node to provide a human readable name.";
     argument name;
   }
+
+  extension type-desc {
+    description
+      "Extend a type to add a desc.";
+    argument name;
+  }
 }

--- a/tests/yang/yolo/yolo-system.yang
+++ b/tests/yang/yolo/yolo-system.yang
@@ -65,7 +65,9 @@ module yolo-system {
         "An URL.";
       key "proto host";
       leaf proto {
-        type types:protocol;
+        type types:protocol {
+          ext:type-desc "<protocol>";
+        }
       }
       leaf host {
         type string;


### PR DESCRIPTION
The ext_size field has been removed with libyang2. Also, there is no parent anymore, the compiled type contains everything needed.

This commit fixes the following error when calling type.extensions():

> File "/(...)/.venv/src/libyang/libyang/schema.py", line 579, in extensions
>   for i in range(self.cdata.ext_size):
> AttributeError: cdata 'struct lysc_type *' has no field 'ext_size'

Fix by using ly_array_count, and add a new test for this case.

Signed-off-by: Samuel Gauthier <samuel.gauthier@6wind.com>