### PR TITLE
schema: fix type patterns return value

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -389,6 +389,15 @@ class LeafTypeTest(unittest.TestCase):
         self.assertEqual(leaf.deprecated(), False)
         self.assertEqual(leaf.obsolete(), True)
 
+    def test_leaf_type_pattern(self):
+        leaf = next(
+            self.ctx.find_path("/yolo-system:conf/yolo-system:url/yolo-system:host")
+        )
+        self.assertIsInstance(leaf, SLeaf)
+        t = leaf.type()
+        self.assertIsInstance(t, Type)
+        self.assertEqual(list(t.patterns()), [("[a-z.]+", False), ("1", True)])
+
     def test_leaf_type_union(self):
         leaf = next(self.ctx.find_path("/yolo-system:conf/yolo-system:number"))
         self.assertIsInstance(leaf, SLeafList)

--- a/tests/yang-old/yolo/yolo-system.yang
+++ b/tests/yang-old/yolo/yolo-system.yang
@@ -60,7 +60,12 @@ module yolo-system {
         type types:protocol;
       }
       leaf host {
-        type string;
+        type string {
+          pattern "[a-z.]+";
+          pattern "1" {
+            modifier "invert-match";
+          }
+        }
       }
       leaf port {
         type uint16;

--- a/tests/yang/yolo/yolo-system.yang
+++ b/tests/yang/yolo/yolo-system.yang
@@ -70,7 +70,12 @@ module yolo-system {
         }
       }
       leaf host {
-        type string;
+        type string {
+          pattern "[a-z.]+";
+          pattern "1" {
+            modifier "invert-match";
+          }
+        }
       }
       leaf port {
         type uint16;


### PR DESCRIPTION
The libyang lysp_type struct arg.str fields contains the pattern string
+ a character in the beginning telling if the match is inverted or not.

Since the libyang2 port, the patterns function do not take this into
account anymore, and yields this string directly, which is not correct.

The patterns function is supposed to yield Iterator[Tuple[str, bool],
containing the pattern string and a boolean telling if the match is
inverted or not, restore it. Add a test for it as well.

While there, use ly_array_iter.

Signed-off-by: Samuel Gauthier <samuel.gauthier@6wind.com>