### PR TITLE
cffi: update lys[c,p]_ext_instance to libyang 2.1.0

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -420,13 +420,16 @@ struct lysp_ext_instance {
     const char *name;
     const char *argument;
     LY_VALUE_FORMAT format;
-    struct lysp_node *parsed;
     void *prefix_data;
-    struct lysp_stmt *child;
+    struct lysp_ext *def;
     void *parent;
     enum ly_stmt parent_stmt;
     uint64_t parent_stmt_index;
     uint16_t flags;
+    const struct lyplg_ext_record *record;
+    struct lysp_ext_substmt *substmts;
+    void *parsed;
+    struct lysp_stmt *child;
 };
 
  struct lysp_import {
@@ -662,11 +665,11 @@ struct lysc_ext_instance {
     const char *argument;
     struct lys_module *module;
     struct lysc_ext_instance *exts;
-    struct lysc_ext_substmt *substmts;
-    void *data;
     void *parent;
     enum ly_stmt parent_stmt;
-    ...;
+    uint64_t parent_stmt_index;
+    struct lysc_ext_substmt *substmts;
+    void *compiled;
 };
 
 struct lysc_ext {

--- a/cffi/source.c
+++ b/cffi/source.c
@@ -9,6 +9,6 @@
 #if (LY_VERSION_MAJOR != 2)
 #error "This version of libyang bindings only works with libyang 2.x"
 #endif
-#if (LY_VERSION_MINOR < 19)
-#error "Need at least libyang 2.19"
+#if (LY_VERSION_MINOR < 25)
+#error "Need at least libyang 2.25"
 #endif


### PR DESCRIPTION
The commit 193dacdfac53 ("plugins exts CHANGE ext parsing isolated into a callback") reworked the lysp_ext_instance and lysc_ext_instance structures.

Take it into account.

Link: https://github.com/CESNET/libyang/commit/193dacdfac53
Fixes: https://github.com/CESNET/libyang-python/issues/57
Signed-off-by: Samuel Gauthier <samuel.gauthier@6wind.com>