### PR TITLE
fix example code in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,7 +185,7 @@ Data Tree
    ...             {'name': 'lo', 'address': '127.0.0.1'},
    ...         ],
    ...     },
-   ... }, config=True)
+   ... })
    >>> print(node.print_mem('xml', pretty=True))
    <data xmlns="urn:example">
      <interface>


### PR DESCRIPTION
Since module.parse_data_dict no longer have keyword `config`, should remove this argument from example code