### PR TITLE
simple merge bugfix

### DIFF
--- a/libyang/data.py
+++ b/libyang/data.py
@@ -552,6 +552,8 @@ class DNode:
         if ret != lib.LY_SUCCESS:
             raise self.context.error("merge failed")
 
+        self.cdata = node_p[0]
+
     def iter_tree(self) -> Iterator["DNode"]:
         n = next_n = self.cdata
         while n != ffi.NULL:


### PR DESCRIPTION
Data DNode.merge() method is attempting to modify self.cdata but
the code ends up creating a new and separate object that contains
the result of the merge. This fix simply overwrites self.cdata with
the result in the new object.

Fixes: #49