### PR TITLE
Instantiate `ly_ctx_new` with `LY_CTX_NO_YANG_LIB`

### DIFF
--- a/libyang/context.py
+++ b/libyang/context.py
@@ -61,6 +61,7 @@ class Context:
         search_path = ":".join(search_paths) if search_paths else None
 
         if yanglib_path is None:
+            options |= lib.LY_CTX_NO_YANGLIBRARY
             if lib.ly_ctx_new(str2c(search_path), options, ctx) != lib.LY_SUCCESS:
                 raise self.error("cannot create context")
         else:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -78,6 +78,46 @@ class DataTest(unittest.TestCase):
         finally:
             dnode.free()
 
+    JSON_CONFIG_WITH_STATE = """{
+  "yolo-system:state": {
+    "speed": 4321
+  },
+  "yolo-system:conf": {
+    "hostname": "foo",
+    "url": [
+      {
+        "proto": "https",
+        "host": "github.com",
+        "path": "/CESNET/libyang-python",
+        "enabled": false
+      },
+      {
+        "proto": "http",
+        "host": "foobar.com",
+        "port": 8080,
+        "path": "/index.html",
+        "enabled": true
+      }
+    ],
+    "number": [
+      1000,
+      2000,
+      3000
+    ],
+    "speed": 1234
+  }
+}
+"""
+
+    def test_data_parse_config_json_without_yang_lib(self):
+        dnode = self.ctx.parse_data_mem(self.JSON_CONFIG, "json")
+        self.assertIsInstance(dnode, DContainer)
+        try:
+            j = dnode.print_mem("json", with_siblings=True)
+            self.assertEqual(j, self.JSON_CONFIG_WITH_STATE)
+        finally:
+            dnode.free()
+
     JSON_CONFIG_ADD_LIST_ITEM = """{
   "yolo-system:conf": {
     "hostname": "foo",


### PR DESCRIPTION
When instantiating a Context without a yang library loading data will trigger the following validation error *unless* the context is instantiated correctly *or* the validation flags `LYD_VALIDATE_NO_STATE` or `LYD_VALIDATE_PRESENT` are used.

```
'Data location "/ietf-yang-library:yang-library".:  Mandatory node
 "content-id" instance does not exist.'
```