### PR TITLE
schema: enable getting node data path without list key

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -282,13 +282,16 @@ class ContainerTest(unittest.TestCase):
 
 # -------------------------------------------------------------------------------------
 class ListTest(unittest.TestCase):
-    SCHEMA_PATH = "/yolo-system:conf/url"
-    DATA_PATH = "/yolo-system:conf/url[host='%s'][proto='%s']"
+    PATH = {
+        "LOG": "/yolo-system:conf/url",
+        "DATA": "/yolo-system:conf/url",
+        "DATA_PATTERN": "/yolo-system:conf/url[host='%s'][proto='%s']",
+    }
 
     def setUp(self):
         self.ctx = Context(YANG_DIR)
         self.ctx.load_module("yolo-system")
-        self.list = next(self.ctx.find_path(self.SCHEMA_PATH))
+        self.list = next(self.ctx.find_path(self.PATH["LOG"]))
 
     def tearDown(self):
         self.list = None
@@ -300,9 +303,11 @@ class ListTest(unittest.TestCase):
         self.assertEqual(self.list.nodetype(), SNode.LIST)
         self.assertEqual(self.list.keyword(), "list")
 
-        self.assertEqual(self.list.schema_path(), self.SCHEMA_PATH)
+        self.assertEqual(self.list.schema_path(), self.PATH["LOG"])
 
-        self.assertEqual(self.list.data_path(), self.DATA_PATH)
+        self.assertEqual(self.list.schema_path(SNode.PATH_DATA), self.PATH["DATA"])
+
+        self.assertEqual(self.list.data_path(), self.PATH["DATA_PATTERN"])
         self.assertFalse(self.list.ordered())
 
     def test_list_keys(self):


### PR DESCRIPTION
There is no way to get a node data path (path without choice/case) without list keys.

Adds the path_type parameter to the SNode.schema_path() method. This parameter can takes 3 values:
 - SNode.PATH_LOG: returns the path with schema-only nodes (choice, case) included, the default
 - SNode.PATH_DATA: returns the path without schema-only nodes
 - SNode.PATH_DATA_PATTERN: similar to PATH_DATA with list keys added (the one used by data_path())

The SNode.PATH_LOG is set by default to not change the original behavior.
The SNode.data_path() method now calls SNode.schema_path() with self.PATH_DATA_PATTERN instead of lib.lysc_path().

Here is an example of the output difference between schema_path(), data_path(), and schema_path(path_type=SNode.PATH_DATA) with a node included in a choice and a list:
node.schema_path():
/ietf-keystore:keystore/asymmetric-keys/asymmetric-key/private-key-type/private-key/private-key node.data_path() or node.schema_path(SNode.PATH_DATA_PATTERN): /ietf-keystore:keystore/asymmetric-keys/asymmetric-key[name='%s']/private-key node.schema_path(SNode.PATH_DATA):
/ietf-keystore:keystore/asymmetric-keys/asymmetric-key/private-key