### PR TITLE
Fixed defaults function output

### DIFF
--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -1209,7 +1209,7 @@ class SLeaf(SNode):
         self.cdata_leaf = ffi.cast("struct lysc_node_leaf *", cdata)
         self.cdata_leaf_parsed = ffi.cast("struct lysp_node_leaf *", self.cdata_parsed)
 
-    def default(self) -> Union[None, bool, int, str]:
+    def default(self) -> Union[None, bool, int, str, float]:
         if not self.cdata_leaf.dflt:
             return None
         val = lib.lyd_value_get_canonical(self.context.cdata, self.cdata_leaf.dflt)
@@ -1221,6 +1221,8 @@ class SLeaf(SNode):
             return val == "true"
         if val_type.base() in Type.NUM_TYPES:
             return int(val)
+        if val_type.base() == Type.DEC64:
+            return float(val)
         return val
 
     def units(self) -> Optional[str]:
@@ -1268,7 +1270,7 @@ class SLeafList(SNode):
             self.context, self.cdata_leaflist.type, self.cdata_leaflist_parsed.type
         )
 
-    def defaults(self) -> Iterator[str]:
+    def defaults(self) -> Iterator[Union[None, bool, int, str, float]]:
         if self.cdata_leaflist.dflts == ffi.NULL:
             return
         arr_length = ffi.cast("uint64_t *", self.cdata_leaflist.dflts)[-1]
@@ -1278,13 +1280,16 @@ class SLeafList(SNode):
             )
             if not val:
                 yield None
-            ret = c2str(val)
-            val_type = self.cdata_leaflist.dflts[i].realtype
-            if val_type == Type.BOOL:
-                ret = val == "true"
-            elif val_type in Type.NUM_TYPES:
-                ret = int(val)
-            yield ret
+            val = c2str(val)
+            val_type = Type(self.context, self.cdata_leaflist.dflts[i].realtype, None)
+            if val_type.base() == Type.BOOL:
+                yield val == "true"
+            elif val_type.base() in Type.NUM_TYPES:
+                yield int(val)
+            elif val_type.base() == Type.DEC64:
+                yield float(val)
+            else:
+                yield val
 
     def must_conditions(self) -> Iterator[str]:
         pdata = self.cdata_leaflist_parsed

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -474,3 +474,34 @@ class LeafTypeTest(unittest.TestCase):
     def test_iter_tree(self):
         leaf = next(self.ctx.find_path("/yolo-system:conf"))
         self.assertEqual(len(list(leaf.iter_tree(full=True))), 23)
+
+
+# -------------------------------------------------------------------------------------
+class LeafTest(unittest.TestCase):
+    def setUp(self):
+        self.ctx = Context(YANG_DIR)
+        self.ctx.load_module("yolo-nodetypes")
+
+    def tearDown(self):
+        self.ctx.destroy()
+        self.ctx = None
+
+    def test_leaf_default(self):
+        leaf = next(self.ctx.find_path("/yolo-nodetypes:conf/percentage"))
+        self.assertIsInstance(leaf.default(), float)
+
+
+# -------------------------------------------------------------------------------------
+class LeafListTest(unittest.TestCase):
+    def setUp(self):
+        self.ctx = Context(YANG_DIR)
+        self.ctx.load_module("yolo-nodetypes")
+
+    def tearDown(self):
+        self.ctx.destroy()
+        self.ctx = None
+
+    def test_leaflist_defaults(self):
+        leaflist = next(self.ctx.find_path("/yolo-nodetypes:conf/ratios"))
+        for d in leaflist.defaults():
+            self.assertIsInstance(d, float)

--- a/tests/yang/yolo/yolo-nodetypes.yang
+++ b/tests/yang/yolo/yolo-nodetypes.yang
@@ -1,0 +1,32 @@
+module yolo-nodetypes {
+  yang-version 1.1;
+  namespace "urn:yang:yolo:nodetypes";
+  prefix sys;
+
+  description
+    "YOLO Nodetypes.";
+
+  revision 2024-01-25 {
+    description
+      "Initial version.";
+  }
+
+  container conf {
+    description
+      "Configuration.";
+    leaf percentage {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      default 10.2;
+    }
+
+    leaf-list ratios {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      default 2.5;
+      default 2.6;
+    }
+  }
+}


### PR DESCRIPTION
This patch fixes output for leaf/leaf-list nodes
using decimal64 type. It also fixes the output of
leaf-list defaults and add new unit test for this
purpose