### PR TITLE
Fix tox/lint issue with python3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: 3.11
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip


### PR DESCRIPTION
This patch force usage of python 3.11 for tox/lint workflows in github as it doesn't work with python 3.12 and above