### PR TITLE
Fixed/Extended context find_path function

### DIFF
--- a/libyang/context.py
+++ b/libyang/context.py
@@ -175,9 +175,19 @@ class Context:
 
         return Module(self, mod)
 
-    def find_path(self, path: str, output: bool = False) -> Iterator[SNode]:
+    def find_path(
+        self,
+        path: str,
+        output: bool = False,
+        root_node: Optional["libyang.SNode"] = None,
+    ) -> Iterator[SNode]:
         if self.cdata is None:
             raise RuntimeError("context already destroyed")
+
+        if root_node is not None:
+            ctx_node = root_node.cdata
+        else:
+            ctx_node = ffi.NULL
 
         flags = 0
         if output:
@@ -185,7 +195,7 @@ class Context:
 
         node_set = ffi.new("struct ly_set **")
         if (
-            lib.lys_find_xpath(self.cdata, ffi.NULL, str2c(path), 0, node_set)
+            lib.lys_find_xpath(self.cdata, ctx_node, str2c(path), 0, node_set)
             != lib.LY_SUCCESS
         ):
             raise self.error("cannot find path")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,7 +4,7 @@
 import os
 import unittest
 
-from libyang import Context, LibyangError, Module, SRpc
+from libyang import Context, LibyangError, Module, SLeaf, SLeafList
 
 
 YANG_DIR = os.path.join(os.path.dirname(__file__), "yang")
@@ -82,8 +82,10 @@ class ContextTest(unittest.TestCase):
     def test_ctx_find_path(self):
         with Context(YANG_DIR) as ctx:
             ctx.load_module("yolo-system")
-            node = next(ctx.find_path("/yolo-system:format-disk"))
-            self.assertIsInstance(node, SRpc)
+            node = next(ctx.find_path("/yolo-system:conf/offline"))
+            self.assertIsInstance(node, SLeaf)
+            node2 = next(ctx.find_path("../number", root_node=node))
+            self.assertIsInstance(node2, SLeafList)
 
     def test_ctx_iter_modules(self):
         with Context(YANG_DIR) as ctx:


### PR DESCRIPTION
This patch enhances context find_path function to allow using relative paths as well, by adding optional root_node, from which the relative path is being evaluated