### PR TITLE
Adding unlink function

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -267,6 +267,8 @@ LY_ERR lys_set_implemented(struct lys_module *,	const char **);
 #define LYD_NEW_PATH_CANON_VALUE ...
 LY_ERR lyd_new_path(struct lyd_node *, const struct ly_ctx *, const char *, const char *, uint32_t, struct lyd_node **);
 LY_ERR lyd_find_xpath(const struct lyd_node *, const char *, struct ly_set **);
+void lyd_unlink_siblings(struct lyd_node *node);
+void lyd_unlink_tree(struct lyd_node *node);
 void lyd_free_all(struct lyd_node *node);
 void lyd_free_tree(struct lyd_node *node);
 

--- a/libyang/data.py
+++ b/libyang/data.py
@@ -868,7 +868,17 @@ class DNode:
             rpcreply=rpcreply,
         )
 
+    def unlink(self, with_siblings: bool = False) -> None:
+        if self.cdata is None or self.cdata == ffi.NULL:
+            return
+        if with_siblings:
+            lib.lyd_unlink_siblings(self.cdata)
+        else:
+            lib.lyd_unlink_tree(self.cdata)
+
     def free_internal(self, with_siblings: bool = True) -> None:
+        if self.cdata is None or self.cdata == ffi.NULL:
+            return
         if with_siblings:
             lib.lyd_free_all(self.cdata)
         else:


### PR DESCRIPTION
This patch adds unlink function from libyang to allow proper node cleanup procedure. It also prevents double freeing of node C data structure