### PR TITLE
Adding fraction_digits function

### DIFF
--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -611,6 +611,22 @@ class Type:
             if rng is not None:
                 yield rng
 
+    def fraction_digits(self) -> Optional[int]:
+        if not self.cdata_parsed:
+            return None
+        if self.cdata.basetype != self.DEC64:
+            return None
+        return self.cdata_parsed.fraction_digits
+
+    def all_fraction_digits(self) -> Iterator[int]:
+        if self.cdata.basetype == lib.LY_TYPE_UNION:
+            for t in self.union_types():
+                yield from t.all_fraction_digits()
+        else:
+            fd = self.fraction_digits()
+            if fd is not None:
+                yield fd
+
     STR_TYPES = frozenset((STRING, BINARY, ENUM, IDENT, BITS))
 
     def length(self) -> Optional[str]:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -474,3 +474,11 @@ class LeafTypeTest(unittest.TestCase):
     def test_iter_tree(self):
         leaf = next(self.ctx.find_path("/yolo-system:conf"))
         self.assertEqual(len(list(leaf.iter_tree(full=True))), 23)
+
+    def test_leaf_type_fraction_digits(self):
+        self.ctx.load_module("yolo-nodetypes")
+        leaf = next(self.ctx.find_path("/yolo-nodetypes:conf/percentage"))
+        self.assertIsInstance(leaf, SLeaf)
+        t = leaf.type()
+        self.assertIsInstance(t, Type)
+        self.assertEqual(next(t.all_fraction_digits(), None), 2)

--- a/tests/yang/yolo/yolo-nodetypes.yang
+++ b/tests/yang/yolo/yolo-nodetypes.yang
@@ -1,0 +1,32 @@
+module yolo-nodetypes {
+  yang-version 1.1;
+  namespace "urn:yang:yolo:nodetypes";
+  prefix sys;
+
+  description
+    "YOLO Nodetypes.";
+
+  revision 2024-01-25 {
+    description
+      "Initial version.";
+  }
+
+  container conf {
+    description
+      "Configuration.";
+    leaf percentage {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      default 10.2;
+    }
+
+    leaf-list ratios {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      default 2.5;
+      default 2.6;
+    }
+  }
+}


### PR DESCRIPTION
This patch introduces fraction_digits() and  all_fraction_digits() functions for SLeaf and SLeafList