### PR TITLE
Adding require_instance function

### DIFF
--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -681,6 +681,12 @@ class Type:
         else:
             yield from self.patterns()
 
+    def require_instance(self) -> Optional[bool]:
+        if self.cdata.basetype != self.LEAFREF:
+            return None
+        t = ffi.cast("struct lysc_type_leafref *", self.cdata)
+        return bool(t.require_instance)
+
     def module(self) -> Module:
         if not self.cdata_parsed:
             return None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -512,6 +512,13 @@ class LeafTypeTest(unittest.TestCase):
         self.assertIsInstance(t, Type)
         self.assertEqual(next(t.all_fraction_digits(), None), 2)
 
+    def test_leaf_type_require_instance(self):
+        leaf = next(self.ctx.find_path("/yolo-system:conf/hostname-ref"))
+        self.assertIsInstance(leaf, SLeaf)
+        t = leaf.type()
+        self.assertIsInstance(t, Type)
+        self.assertFalse(t.require_instance())
+
 
 # -------------------------------------------------------------------------------------
 class LeafTest(unittest.TestCase):

--- a/tests/yang/yolo/yolo-system.yang
+++ b/tests/yang/yolo/yolo-system.yang
@@ -43,6 +43,7 @@ module yolo-system {
     leaf hostname-ref {
       type leafref {
         path "../hostname";
+        require-instance false;
       }
     }
 


### PR DESCRIPTION
This patch introduces require_instance function, to allow user to get information whether the leafref requires valid instace prior being instanciated