### PR TITLE
Context: adding disable_searchdirs options

### DIFF
--- a/libyang/context.py
+++ b/libyang/context.py
@@ -26,6 +26,7 @@ class Context:
     def __init__(
         self,
         search_path: Optional[str] = None,
+        disable_searchdirs: bool = False,
         disable_searchdir_cwd: bool = True,
         explicit_compile: Optional[bool] = False,
         leafref_extended: bool = False,
@@ -33,11 +34,17 @@ class Context:
         yanglib_fmt: str = "json",
         cdata=None,  # C type: "struct ly_ctx *"
     ):
+        self._module_data_clb = None
+        self._cffi_handle = ffi.new_handle(self)
+        self._cdata_modules = []
+
         if cdata is not None:
             self.cdata = ffi.cast("struct ly_ctx *", cdata)
             return  # already initialized
 
         options = 0
+        if disable_searchdirs:
+            options |= lib.LY_CTX_DISABLE_SEARCHDIRS
         if disable_searchdir_cwd:
             options |= lib.LY_CTX_DISABLE_SEARCHDIR_CWD
         if explicit_compile:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -111,3 +111,8 @@ class ContextTest(unittest.TestCase):
         with Context(YANG_DIR, leafref_extended=True) as ctx:
             mod = ctx.load_module("yolo-leafref-extended")
             self.assertIsInstance(mod, Module)
+
+    def test_ctx_disable_searchdirs(self):
+        with Context(YANG_DIR, disable_searchdirs=True) as ctx:
+            with self.assertRaises(LibyangError):
+                ctx.load_module("yolo-nodetypes")


### PR DESCRIPTION
This patch adds support to disable searching of local directories during loading of module