### PR TITLE
xpath: add support for indexed xpath

### DIFF
--- a/tests/test_xpath.py
+++ b/tests/test_xpath.py
@@ -41,6 +41,11 @@ class XPathTest(unittest.TestCase):
         )
         ly.xpath_set(d, "/lstnum[.='100']", 100)
         ly.xpath_set(d, "/lstnum[.='1']", 1, after="")
+        ly.xpath_set(d, "/lstnum[5]", 33, after="4")
+        ly.xpath_set(d, "/lstnum[5]", 34, after="4")
+        ly.xpath_set(d, "/lstnum[5]", 35, after="4")
+        ly.xpath_set(d, "/lstnum[7]", 101, after="6")
+        ly.xpath_set(d, "/lstnum[8]", 102, after="7")
         with self.assertRaises(ValueError):
             ly.xpath_set(d, "/lstnum[.='1000']", 1000, after="1000000")
         with self.assertRaises(ValueError):
@@ -101,7 +106,7 @@ class XPathTest(unittest.TestCase):
                     {"name": "eth3", "mtu": 1000},
                 ],
                 "lst2": ["a", "b", "c"],
-                "lstnum": [1, 10, 20, 30, 40, 100],
+                "lstnum": [1, 10, 20, 30, 35, 100, 101, 102],
                 "val": 43,
             },
         )


### PR DESCRIPTION
This patch adds support for indexed xpath to xpath_set. In the case of a leaf-list, it is now possible to apply xpath_set in this way:

xpath_set(d, "/lstnum[5]", 33, after="4")

This will replace the 5th element of the leaf-list with the new value 33.

This feature is important because libyang can return this type of xpath when a callback is called with sr_module_change_subscribe from sysrepo.

The tests are updated accordingly.