### PR TITLE
data: adds ignore_none options into dict_to_dnode

### DIFF
--- a/libyang/data.py
+++ b/libyang/data.py
@@ -1147,6 +1147,8 @@ def dict_to_dnode(
     rpc: bool = False,
     rpcreply: bool = False,
     notification: bool = False,
+    store_only: bool = False,
+    ignore_none: bool = False,
 ) -> Optional[DNode]:
     """
     Convert a python dictionary to a DNode object given a YANG module object. The return
@@ -1173,6 +1175,8 @@ def dict_to_dnode(
         Data represents RPC or action output parameters.
     :arg notification:
         Data represents notification parameters.
+    :arg ignore_none:
+        Whether to ignore None values in dict or not
     """
     if not dic:
         return None
@@ -1320,6 +1324,8 @@ def dict_to_dnode(
                 continue
 
             value = _dic[key]
+            if value is None and ignore_none:
+                continue
 
             if isinstance(s, SLeaf):
                 _create_leaf(_parent, module, name, value, in_rpc_output)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1036,3 +1036,11 @@ class DataTest(unittest.TestCase):
 
         attrs.remove("ietf-netconf:operation")
         self.assertEqual(len(attrs), 0)
+
+    def test_dnode_dict_to_dnode_ignore_none(self):
+        data = {"yolo-nodetypes:ip-address": None}
+        module = self.ctx.load_module("yolo-nodetypes")
+        dnode = dict_to_dnode(
+            data, module, None, validate=False, store_only=True, ignore_none=True
+        )
+        self.assertIsNone(dnode)


### PR DESCRIPTION
This patch adds new option, which will skip creation of dnodes, when the value in dict is set to None