### PR TITLE
data: add before option into insert_sibling API

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -999,6 +999,8 @@ LY_ERR lyd_merge_tree(struct lyd_node **, const struct lyd_node *, uint16_t);
 LY_ERR lyd_merge_siblings(struct lyd_node **, const struct lyd_node *, uint16_t);
 LY_ERR lyd_insert_child(struct lyd_node *, struct lyd_node *);
 LY_ERR lyd_insert_sibling(struct lyd_node *, struct lyd_node *, struct lyd_node **);
+LY_ERR lyd_insert_after(struct lyd_node *, struct lyd_node *);
+LY_ERR lyd_insert_before(struct lyd_node *, struct lyd_node *);
 LY_ERR lyd_diff_apply_all(struct lyd_node **, const struct lyd_node *);
 
 #define LYD_DUP_NO_META  ...

--- a/libyang/data.py
+++ b/libyang/data.py
@@ -401,8 +401,13 @@ class DNode:
         if ret != lib.LY_SUCCESS:
             raise self.context.error("cannot insert node")
 
-    def insert_sibling(self, node):
-        ret = lib.lyd_insert_sibling(self.cdata, node.cdata, ffi.NULL)
+    def insert_sibling(self, node, before: Optional[bool] = None):
+        if before is None:
+            ret = lib.lyd_insert_sibling(self.cdata, node.cdata, ffi.NULL)
+        elif before:
+            ret = lib.lyd_insert_before(self.cdata, node.cdata)
+        else:
+            ret = lib.lyd_insert_after(self.cdata, node.cdata)
         if ret != lib.LY_SUCCESS:
             raise self.context.error("cannot insert sibling")
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -953,6 +953,23 @@ class DataTest(unittest.TestCase):
         self.assertIsInstance(sibling, DLeaf)
         self.assertEqual(sibling.cdata, dnode2.cdata)
 
+    def test_dnode_insert_sibling_before_after(self):
+        R1 = {"yolo-nodetypes:records": [{"id": "id1", "name": "name1"}]}
+        R2 = {"yolo-nodetypes:records": [{"id": "id2", "name": "name2"}]}
+        R3 = {"yolo-nodetypes:records": [{"id": "id3", "name": "name3"}]}
+        module = self.ctx.get_module("yolo-nodetypes")
+        dnode1 = dict_to_dnode(R1, module, None, validate=False)
+        dnode2 = dict_to_dnode(R2, module, None, validate=False)
+        dnode3 = dict_to_dnode(R3, module, None, validate=False)
+        self.assertEqual(dnode1.first_sibling().cdata, dnode1.cdata)
+        dnode1.insert_sibling(dnode2, True)
+        dnode1.insert_sibling(dnode3, False)
+        self.assertEqual(
+            [dnode2.cdata, dnode1.cdata, dnode3.cdata],
+            [s.cdata for s in dnode1.first_sibling().siblings()],
+        )
+        self.assertEqual(dnode1.first_sibling().cdata, dnode2.cdata)
+
     def _create_opaq_hostname(self):
         root = self.ctx.create_data_path(path="/yolo-system:conf")
         root.new_path(

--- a/tests/yang/yolo/yolo-nodetypes.yang
+++ b/tests/yang/yolo/yolo-nodetypes.yang
@@ -20,6 +20,7 @@ module yolo-nodetypes {
       type string;
       default "ASD";
     }
+    ordered-by user;
   }
 
   container conf {


### PR DESCRIPTION
This patch adds "before" option into insert_sibling API, which allows user to specify, where to insert the sibling in case of ordered (leaf-)lists