### PR TITLE
tox: bumped Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: 3.6
-            toxenv: py36
-          - python: 3.7
-            toxenv: py37
-          - python: 3.8
-            toxenv: py38
           - python: 3.9
             toxenv: py39
           - python: "3.10"
@@ -54,6 +48,8 @@ jobs:
             toxenv: py311
           - python: "3.12"
             toxenv: py312
+          - python: "3.13"
+            toxenv: py313
           - python: pypy3.9
             toxenv: pypy3
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = format,lint,py{36,37,38,39,310,311,312,py3,3},lydevel,coverage
+envlist = format,lint,py{39,310,311,312,313,py3},lydevel,coverage
 skip_missing_interpreters = true
 isolated_build = true
 distdir = {toxinidir}/dist


### PR DESCRIPTION
* `envlist` looks for Python 3.9 to 3.13; these are [the ones being supported](https://devguide.python.org/versions/)
* dropped 3.6 to 3.8 from CI/CD tests
* removed `py3`: it is never used, since [first found wins](https://tox.wiki/en/stable/config.html#python-options)

```shell
# tox -l
format
lint
py39
py310
py311
py312
py313
pypy3
lydevel
coverage
```