### PR TITLE
schema: add store_only parameter to parse_data_dict

### DIFF
--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -241,6 +241,7 @@ class Module:
         rpc: bool = False,
         rpcreply: bool = False,
         notification: bool = False,
+        store_only: bool = False,
     ) -> "libyang.data.DNode":
         """
         Convert a python dictionary to a DNode object following the schema of this
@@ -276,6 +277,7 @@ class Module:
             rpc=rpc,
             rpcreply=rpcreply,
             notification=notification,
+            store_only=store_only,
         )
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1112,3 +1112,22 @@ class DataTest(unittest.TestCase):
         self.assertIsInstance(dnode, DLeaf)
         self.assertEqual(dnode.value(), "test")
         dnode.free()
+
+    def test_merge_store_only(self):
+        MAIN = {"yolo-nodetypes:test1": 50}
+        module = self.ctx.load_module("yolo-nodetypes")
+        dnode = module.parse_data_dict(MAIN, validate=False, store_only=True)
+        self.assertIsInstance(dnode, DLeaf)
+        self.assertEqual(dnode.value(), 50)
+        dnode.free()
+
+    def test_merge_builtin_plugins_only(self):
+        MAIN = {"yolo-nodetypes:ip-address": "test"}
+        self.tearDown()
+        gc.collect()
+        self.ctx = Context(YANG_DIR, builtin_plugins_only=True)
+        module = self.ctx.load_module("yolo-nodetypes")
+        dnode = module.parse_data_dict(MAIN, validate=False, store_only=True)
+        self.assertIsInstance(dnode, DLeaf)
+        self.assertEqual(dnode.value(), "test")
+        dnode.free()


### PR DESCRIPTION
Sometimes it is necessary to store only the data.

Signed-off-by: Jeremie Leska <jeremie.leska@6wind.com>