### PR TITLE
Generalize load module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
 
   check-commits:
     if: ${{ github.event.pull_request.commits }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       LYPY_COMMIT_RANGE: "HEAD~${{ github.event.pull_request.commits }}.."
     steps:
-      - run: sudo apt-get install git make
+      - run: sudo apt-get install git make jq curl
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/check-commits.sh
+++ b/check-commits.sh
@@ -42,11 +42,10 @@ err() {
 }
 
 check_issue() {
-	json=$(curl -f -X GET -L --no-progress-meter \
+	curl -f -X GET -L --no-progress-meter \
 		-H "Accept: application/vnd.github+json" \
 		-H "X-GitHub-Api-Version: 2022-11-28" \
-		"$api_url/issues/${1##*/}") || return 1
-	test $(echo "$json" | jq -r .state) = open
+		"$api_url/issues/${1##*/}" | jq -r .state | grep -Fx open
 }
 
 for rev in $revisions; do

--- a/libyang/context.py
+++ b/libyang/context.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
-from typing import IO, Any, Callable, Iterator, Optional, Tuple, Union
+from typing import IO, Any, Callable, Iterator, Optional, Sequence, Tuple, Union
 
 from _libyang import ffi, lib
 from .data import (
@@ -340,10 +340,19 @@ class Context:
     def parse_module_str(self, s: str, fmt: str = "yang", features=None) -> Module:
         return self.parse_module(s, IOType.MEMORY, fmt, features)
 
-    def load_module(self, name: str) -> Module:
+    def load_module(
+        self,
+        name: str,
+        revision: Optional[str] = None,
+        enabled_features: Sequence[str] = (),
+    ) -> Module:
         if self.cdata is None:
             raise RuntimeError("context already destroyed")
-        mod = lib.ly_ctx_load_module(self.cdata, str2c(name), ffi.NULL, ffi.NULL)
+        if enabled_features:
+            features = tuple([str2c(f) for f in enabled_features] + [ffi.NULL])
+        else:
+            features = ffi.NULL
+        mod = lib.ly_ctx_load_module(self.cdata, str2c(name), str2c(revision), features)
         if mod == ffi.NULL:
             raise self.error("cannot load module")
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -63,6 +63,13 @@ class ContextTest(unittest.TestCase):
             mod = ctx.load_module("yolo-system")
             self.assertIsInstance(mod, Module)
 
+    def test_ctx_load_module_with_features(self):
+        with Context(YANG_DIR) as ctx:
+            mod = ctx.load_module("yolo-system", None, ["*"])
+            self.assertIsInstance(mod, Module)
+            for f in list(mod.features()):
+                self.assertTrue(f.state())
+
     def test_ctx_get_module(self):
         with Context(YANG_DIR) as ctx:
             ctx.load_module("yolo-system")


### PR DESCRIPTION
This is an attempt to fix #101, however, it doesn't work as expected and I don't know why. Perhaps you can give me a hint?

The issue is how to pass a list of features into the C API. I implemented the helper function `strlist2c` for that purpose based on the example in the ffi documentation: [An example of calling a main-like thing](https://cffi.readthedocs.io/en/latest/using.html#an-example-of-calling-a-main-like-thing)
However, the pointers/memory received by the C API seem not to be valid.

Do you have an idea what's going wrong here?