### PR TITLE
data: Adding ability to get target_nodes

### DIFF
--- a/libyang/data.py
+++ b/libyang/data.py
@@ -1015,7 +1015,7 @@ class DNode:
 
     def leafref_nodes(self) -> Iterator["DNode"]:
         """
-        Gets the leafref links record for given node.
+        Gets the nodes that are referring to this node.
 
         Requires leafref_linking to be set on the libyang context.
         """
@@ -1024,6 +1024,19 @@ class DNode:
         if lib.lyd_leafref_get_links(term_node, out) != lib.LY_SUCCESS:
             return
         for n in ly_array_iter(out[0].leafref_nodes):
+            yield DNode.new(self.context, n)
+
+    def target_nodes(self) -> Iterator["DNode"]:
+        """
+        Gets the target nodes that are referred by this node.
+
+        Requires leafref_linking to be set on the libyang context.
+        """
+        term_node = ffi.cast("struct lyd_node_term *", self.cdata)
+        out = ffi.new("const struct lyd_leafref_links_rec **")
+        if lib.lyd_leafref_get_links(term_node, out) != lib.LY_SUCCESS:
+            return
+        for n in ly_array_iter(out[0].target_nodes):
             yield DNode.new(self.context, n)
 
     def __repr__(self):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1092,6 +1092,9 @@ class DataTest(unittest.TestCase):
         dnode4 = next(dnode3.leafref_nodes())
         self.assertIsInstance(dnode4, DLeaf)
         self.assertEqual(dnode4.cdata, dnode2.cdata)
+        dnode5 = next(dnode4.target_nodes())
+        self.assertIsInstance(dnode5, DLeaf)
+        self.assertEqual(dnode5.cdata, dnode3.cdata)
         dnode1.free()
 
     def test_dnode_store_only(self):


### PR DESCRIPTION
This patch introduces target_nodes API, which allows user to get all target data nodes that current leafref node is pointing to