### PR TITLE
data: add structured error in exception

### DIFF
--- a/libyang/util.py
+++ b/libyang/util.py
@@ -2,16 +2,34 @@
 # Copyright (c) 2021 RACOM s.r.o.
 # SPDX-License-Identifier: MIT
 
+from dataclasses import dataclass
 import enum
-from typing import Optional
+from typing import Iterable, Optional
 import warnings
 
 from _libyang import ffi, lib
 
 
 # -------------------------------------------------------------------------------------
+@dataclass(frozen=True)
+class LibyangErrorItem:
+    msg: Optional[str]
+    data_path: Optional[str]
+    schema_path: Optional[str]
+    line: Optional[int]
+
+
+# -------------------------------------------------------------------------------------
 class LibyangError(Exception):
-    pass
+    def __init__(
+        self, message: str, *args, errors: Optional[Iterable[LibyangErrorItem]] = None
+    ):
+        super().__init__(message, *args)
+        self.message = message
+        self.errors = tuple(errors or ())
+
+    def __str__(self):
+        return self.message
 
 
 # -------------------------------------------------------------------------------------

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -289,6 +289,18 @@ class DataTest(unittest.TestCase):
             "Data path: /yolo-system:conf/url[proto='https'] (line 7)",
         )
 
+        first = cm.exception.errors[0]
+        self.assertEqual(first.msg, 'Invalid boolean value "abcd".')
+        self.assertEqual(
+            first.data_path, "/yolo-system:conf/url[proto='https']/enabled"
+        )
+        self.assertEqual(first.line, 6)
+
+        second = cm.exception.errors[1]
+        self.assertEqual(second.msg, 'List instance is missing its key "host".')
+        self.assertEqual(second.data_path, "/yolo-system:conf/url[proto='https']")
+        self.assertEqual(second.line, 7)
+
     XML_STATE = """<state xmlns="urn:yang:yolo:system">
   <hostname>foo</hostname>
   <url>


### PR DESCRIPTION
Refactor LibyangError exception handling with structured details. This allows access to each particular error caused by the preceding libyang call. This is especially useful when handling multiple data validation errors, where access to the data path of invalid items is needed.