### PR TITLE
ci: add v3 release branch to workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,11 @@ on:
   pull_request:
     branches:
       - master
+      - b_3.x
   push:
     branches:
       - master
+      - b_3.x
     tags:
       - v*
 


### PR DESCRIPTION
Github needs to see all the triggers on the master/main branch version of this file for them to work.