### PR TITLE
schema: remove error after lyd_value_validate_dflt call

### DIFF
--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -1545,7 +1545,7 @@ class SLeaf(SNode):
                 val_type_cdata,
                 ffi.NULL,
             )
-            if ret != lib.LY_SUCCESS:
+            if ret not in (lib.LY_SUCCESS, lib.LY_EINCOMPLETE):
                 raise self.context.error("Unable to get real type of default value")
             self.cdata_default_realtype = Type(self.context, val_type_cdata[0], None)
 
@@ -1619,7 +1619,7 @@ class SLeafList(SNode):
                     val_type_cdata,
                     ffi.NULL,
                 )
-                if ret != lib.LY_SUCCESS:
+                if ret not in (lib.LY_SUCCESS, lib.LY_EINCOMPLETE):
                     raise self.context.error("Unable to get real type of default value")
                 self.cdata_default_realtypes.append(
                     Type(self.context, val_type_cdata[0], None)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -732,6 +732,9 @@ class LeafTest(unittest.TestCase):
     def test_leaf_default(self):
         leaf = next(self.ctx.find_path("/yolo-nodetypes:conf/percentage"))
         self.assertIsInstance(leaf.default(), float)
+        leaf = next(self.ctx.find_path("/yolo-nodetypes:conf/leafref1"))
+        self.assertIsInstance(leaf.default(), str)
+        self.assertEqual("ASD", leaf.default())
 
     def test_leaf_parsed(self):
         leaf = next(self.ctx.find_path("/yolo-nodetypes:conf/percentage"))
@@ -789,6 +792,9 @@ class LeafListTest(unittest.TestCase):
         leaflist = next(self.ctx.find_path("/yolo-nodetypes:conf/integers"))
         for d in leaflist.defaults():
             self.assertIsInstance(d, int)
+        leaflist3 = next(self.ctx.find_path("/yolo-nodetypes:conf/leaf-list3"))
+        for d in leaflist3.defaults():
+            self.assertIsInstance(d, str)
 
     def test_leaf_list_min_max(self):
         leaflist1 = next(self.ctx.find_path("/yolo-nodetypes:conf/leaf-list1"))

--- a/tests/yang/yolo/yolo-nodetypes.yang
+++ b/tests/yang/yolo/yolo-nodetypes.yang
@@ -93,6 +93,20 @@ module yolo-nodetypes {
     leaf-list leaf-list2 {
       type string;
     }
+
+    leaf leafref1 {
+      type leafref {
+        path "/records/name";
+      }
+      default "ASD";
+    }
+
+    leaf-list leaf-list3 {
+      type leafref {
+        path "/records/name";
+      }
+      default "ASD";
+    }
   }
 
   leaf test1 {


### PR DESCRIPTION
libyang returns the realtype field when the store callback return code is LY_SUCCESS and LY_EINCOMPLETE.
Don't raise an error when lyd_value_validate_dflt returns LY_EINCOMPLETE. The function can then use the val_type_cdata field.

Link: https://github.com/CESNET/libyang/blob/master/src/tree_data_common.c#L682