### PR TITLE
context: remove debug print

### DIFF
--- a/check-commits.sh
+++ b/check-commits.sh
@@ -104,7 +104,7 @@ for rev in $revisions; do
 		if [ -z "$value" ]; then
 			continue
 		fi
-		fixes_rev=$(echo "$value" | sed -En 's/([A-Fa-f0-9]{7,}[[:space:]]\(".*"\))/\1/p')
+		fixes_rev=$(echo "$value" | sed -En 's/([A-Fa-f0-9]{7,})[[:space:]]\(".*"\)/\1/p')
 		if ! git cat-file commit "$fixes_rev" >/dev/null; then
 			err "trailer '$value' does not refer to a known commit"
 		fi

--- a/libyang/context.py
+++ b/libyang/context.py
@@ -262,7 +262,6 @@ class Context:
                 fmt = lib.LYD_JSON
             else:
                 fmt = lib.LYD_XML
-            print("steweg", search_path, yanglib_path, yanglib_fmt, options)
             ret = lib.ly_ctx_new_ylpath(
                 str2c(search_path), str2c(yanglib_path), fmt, options, ctx
             )

--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -110,6 +110,11 @@ class Module:
         for i in features_list:
             yield Feature(self.context, i)
 
+    def compiled_enabled_features(self) -> Iterator[str]:
+        if self.cdata.compiled:
+            for f in ly_array_iter(self.cdata.compiled.features):
+                yield c2str(f)
+
     def get_feature(self, name: str) -> "Feature":
         for f in self.features():
             if f.name() == name:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -108,6 +108,11 @@ class ModuleTest(unittest.TestCase):
         features = list(self.module.features())
         self.assertEqual(len(features), 2)
 
+    def test_mod_compiled_enabled_features(self):
+        self.module.feature_enable("*")
+        features = list(self.module.compiled_enabled_features())
+        self.assertEqual(len(features), 2)
+
     def test_mod_get_feature(self):
         self.module.feature_enable("turbo-boost")
         feature = self.module.get_feature("turbo-boost")


### PR DESCRIPTION
This log was introduced for debug. Remove it.

Fixes: 0a4b09f461a3 ("cffi: allows to usage of libyang v4")