### PR TITLE
schema: check parsed object before use

### DIFF
--- a/libyang/schema.py
+++ b/libyang/schema.py
@@ -1568,7 +1568,11 @@ class SLeaf(SNode):
         return c2str(self.cdata_leaf.units)
 
     def type(self) -> Type:
-        return Type(self.context, self.cdata_leaf.type, self.cdata_leaf_parsed.type)
+        return Type(
+            self.context,
+            self.cdata_leaf.type,
+            self.cdata_leaf_parsed.type if self.cdata_leaf_parsed else None,
+        )
 
     def is_key(self) -> bool:
         if self.cdata_leaf.flags & lib.LYS_KEY:
@@ -1600,7 +1604,9 @@ class SLeafList(SNode):
 
     def type(self) -> Type:
         return Type(
-            self.context, self.cdata_leaflist.type, self.cdata_leaflist_parsed.type
+            self.context,
+            self.cdata_leaflist.type,
+            self.cdata_leaflist_parsed.type if self.cdata_leaflist_parsed else None,
         )
 
     def defaults(self) -> Iterator[Union[None, bool, int, str, float]]:


### PR DESCRIPTION
With libyang/sysrepo 4 and printed contexts, the parsed object can be null.
Check the parsed object before using it.
If the parsed object is missing:
- Module methods won't yield anything.
- ExtensionParsed _module_from_parsed raises an exception.
- SNode if_features won't yield anything.
- Create a Type object without the parsed type.
- The Container presence returns None.
- For list and leaflist order, return the info from the compiled object.

Fixes: 0a4b09f461a3 ("cffi: allows to usage of libyang v4")